### PR TITLE
Use feature_mask for logcellcounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0] - 2024-06-17
+## [0.2.0] - 2024-06-18
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking
 
-WIP
 * `scparams` now uses `feature_mask` when computing `logcellcounts`. This is important there are multiple modalities in the data (e.g. Gene Expression and Antibody counts.)
+* `sctransform` now takes `feature_mask` parameter, which controls which features are used to compute `logcellcounts`. Defaults to only using "Gene Expression" features.
 * Caching of `scparams` results now uses `StableHashTraits` for hashing.
-* `sctransform` now takes `feature_mask` parameter, which controls which features are used to compute `logcellcounts`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# SCTransform.jl changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Breaking
+
+WIP
+* `scparams` now uses `feature_mask` when computing `logcellcounts`. This is important there are multiple modalities in the data (e.g. Gene Expression and Antibody counts.)
+* Caching of `scparams` results now uses `StableHashTraits` for hashing.
+* `sctransform` now takes `feature_mask` parameter, which controls which features are used to compute `logcellcounts`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2024-06-17
+
 ### Breaking
 
-* `scparams` now uses `feature_mask` when computing `logcellcounts`. This is important there are multiple modalities in the data (e.g. Gene Expression and Antibody counts.)
+* `scparams` now uses `feature_mask` when computing `logcellcounts`. This is important if there are multiple modalities in the data (e.g. Gene Expression and Antibody counts.)
 * `sctransform` now takes `feature_mask` parameter, which controls which features are used to compute `logcellcounts`. Defaults to only using "Gene Expression" features.
 * Caching of `scparams` results now uses `StableHashTraits` for hashing.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SCTransform"
 uuid = "f56ea72b-d1ea-403e-9c0c-95d94e8a8532"
 authors = ["Rasmus Henningsson <rasmus.henningsson@med.lu.se>"]
-version = "0.1.3"
+version = "0.2.0"
 
 [deps]
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
@@ -14,6 +14,7 @@ SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 Scratch = "6c6a2e73-6563-6170-7368-637461726353"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
+StableHashTraits = "c5dd0088-6c3f-4803-b00e-f31a60c170fa"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
@@ -28,6 +29,7 @@ SHA = "0.7"
 Scratch = "1.1"
 SparseArrays = "1"
 SpecialFunctions = "0.10, 1, 2"
+StableHashTraits = "1.2.0"
 Statistics = "1"
 julia = "1.8"
 

--- a/Project.toml
+++ b/Project.toml
@@ -35,8 +35,10 @@ julia = "1.8"
 
 [extras]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SingleCell10x = "eddce310-d14b-4c2d-aa06-cfe9e2f7af98"
+StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "SingleCell10x", "DataFrames"]
+test = ["Test", "SingleCell10x", "DataFrames", "Random", "StableRNGs"]

--- a/src/SCTransform.jl
+++ b/src/SCTransform.jl
@@ -15,6 +15,7 @@ using Scratch
 using SHA
 using DelimitedFiles
 using CodecZlib
+using StableHashTraits
 
 include("utils.jl")
 include("table.jl")

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -1,4 +1,4 @@
-const SCPARAMS_VERSION = v"0.1.1" # TODO: change to 0.2
+const SCPARAMS_VERSION = v"0.2.0"
 
 function _scparams_checksum(X::SparseMatrixCSC, method, min_cells, feature_mask)
 	@assert method in (:poisson, :nb) "Method must be :poisson or :nb"

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -1,6 +1,6 @@
 const SCPARAMS_VERSION = v"0.2.0"
 
-function _scparams_checksum(X::SparseMatrixCSC, method, min_cells, feature_mask)
+function _scparams_checksum(X::SparseMatrixCSC, method::Symbol, min_cells::Int, feature_mask::BitVector)
 	@assert method in (:poisson, :nb) "Method must be :poisson or :nb"
 	P,N = size(X)
 

--- a/src/params.jl
+++ b/src/params.jl
@@ -378,7 +378,7 @@ See also: [`sctransform`](@ref)
 """
 function scparams(::Type{T}, X::AbstractSparseMatrix, features;
                   method=:poisson,
-                  min_cells::Integer=5,
+                  min_cells::Int=5,
                   feature_type = hasproperty(features, :feature_type) ? "Gene Expression" : nothing,
                   feature_mask = feature_type !== nothing ? features.feature_type.==feature_type : trues(size(X,1)),
                   feature_names = hasproperty(features,:name) ? features.name : features.id,
@@ -389,6 +389,7 @@ function scparams(::Type{T}, X::AbstractSparseMatrix, features;
                   kwargs...) where T
 	P,N = size(X)
 	length(feature_names) == P || throw(DimensionMismatch("The number of rows in the count matrix and the number of features do not match."))
+	feature_mask = convert(BitVector, feature_mask)
 
 	if cache_read || cache_write
 		h = _scparams_checksum(X,method,min_cells,feature_mask)

--- a/src/transform.jl
+++ b/src/transform.jl
@@ -1,9 +1,11 @@
 """
 	sctransform(X::AbstractSparseMatrix, features, params;
-                transpose = false,
-                feature_id_columns = [:id,:feature_type],
-                cell_ind = 1:size(X,2),
-                clip=sqrt(size(X,2)/30))
+	            transpose = false,
+	            feature_id_columns = [:id,:feature_type],
+	            feature_type,
+	            feature_mask,
+	            cell_ind = 1:size(X,2),
+	            clip=sqrt(size(X,2)/30))
 
 Computes the SCTransform of the sparse matrix `X`, with features as rows and cells as columns.
 `features` should be a table (e.g. DataFrame or NamedTuple) with feature annotations.
@@ -11,6 +13,8 @@ Computes the SCTransform of the sparse matrix `X`, with features as rows and cel
 
 * `transpose` - set to true to transpose the output (cells as rows, features as columns).
 * `feature_id_columns` is a vector of column names in `features`. The rows in `features` must be unique based on these columns.
+* `feature_type` - Convenience parameter used for `feature_mask` default. Defaults to "Gene Expression" if `features` has a `feature_type` column.
+* `feature_mask` - Vector of booleans deciding which features to use. If set explicitly, the `feature_type` parameter is ignored, otherwise `feature_mask` defaults to only choosing the `feature_type` specified. Affects how logcellcounts are computed. Normally expected to match `feature_mask` used when calling `scparams`.
 * `cell_ind` is vector of cell indices to include in the output. This is computationally more efficient than subsetting afterwards, but yields the same result.
 * `clip` - values less than `-clip` or larger than `clip` are clamped, to reduce the impact of outliers.
 
@@ -19,6 +23,8 @@ See also: [`scparams`](@ref)
 function sctransform(X::AbstractSparseMatrix, features, params;
                      transpose = false,
                      feature_id_columns = [:id,:feature_type],
+                     feature_type = hasproperty(features, :feature_type) ? "Gene Expression" : nothing,
+                     feature_mask = feature_type !== nothing ? features.feature_type.==feature_type : trues(size(X,1)),
                      cell_ind = 1:size(X,2),
                      clip=sqrt(size(X,2)/30))
 
@@ -40,8 +46,7 @@ function sctransform(X::AbstractSparseMatrix, features, params;
 	any(isnothing, feature_ind) && throw(DomainError("Feature ids in `params` does not match ids in `features`."))
 
 
-
-	logCellCounts = logcellcounts(X)[cell_ind]
+	logCellCounts = logcellcounts(X, feature_mask)[cell_ind]
 
 	# TODO: Do not create intermediate X[feature_ind,cell_ind]
 	X = X[feature_ind,cell_ind]

--- a/src/transform.jl
+++ b/src/transform.jl
@@ -30,6 +30,8 @@ function sctransform(X::AbstractSparseMatrix, features, params;
 
 	@assert size(X,1)==length(getproperty(features,first(propertynames(features)))) "The number of rows in X and features must match"
 
+	feature_mask = convert(BitVector, feature_mask)
+
 	β0 = params.beta0
 	β1 = params.beta1
 	θ  = params.theta


### PR DESCRIPTION
This improves handling of datasets with multiple modalities, ensuring that `logcellcounts` is only computed using the correct `feature_type`.

This is a BREAKING change since `scparams`/`sctransform` will give different output from the same input.

Thus, we also the internal `SCPARAMS_VERSION` to ensure that hashes are different from before and avoid loading old results from the cache. And we take the chance to move from an in-house hash to `StableHashTraits`.